### PR TITLE
Ensure SendEmail Submit Action parameters are generated as valid JSON.

### DIFF
--- a/src/WFFM.ConversionTool.Extensions.SitecoreFormsSendEmailSubmitAction/Converters/SendEmailConverter.cs
+++ b/src/WFFM.ConversionTool.Extensions.SitecoreFormsSendEmailSubmitAction/Converters/SendEmailConverter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Text.RegularExpressions;
 using WFFM.ConversionTool.Library.Converters;
 using WFFM.ConversionTool.Library.Helpers;
@@ -29,9 +30,18 @@ namespace WFFM.ConversionTool.Extensions.SitecoreFormsSendEmailSubmitAction.Conv
 			var subject = ConvertFieldTokens(XmlHelper.GetXmlElementValue(sourceValue, "subject"));
 			var mail = ConvertFieldTokens(XmlHelper.GetXmlElementValue(sourceValue, "mail"));
 
-			var formValue = !string.IsNullOrEmpty(from) ? from : localfrom;
+			var fromValue = !string.IsNullOrEmpty(from) ? from : localfrom;
 
-			return $"{{\"from\":\"{formValue}\",\"to\":\"{to}\",\"cc\":\"{cc}\",\"bcc\":\"{bcc}\",\"subject\":\"{subject}\",\"message\":\"{mail}\",\"isHtml\":{isbodyhtml},\"customSmtpConfig\":\"<Host>{host}</Host>\"}}";
+			return JsonConvert.SerializeObject(new { 
+				from = fromValue,
+				to = to,
+				cc = cc,
+				bcc = bcc,
+				subject = subject,
+				message = mail,
+				isHtml = isbodyhtml,
+				customSmtpConfig = $"<Host>{host}</Host>"
+			});
 		}
 
 		private string ConvertFieldTokens(string fieldText)

--- a/src/WFFM.ConversionTool.Extensions.SitecoreFormsSendEmailSubmitAction/WFFM.ConversionTool.Extensions.SitecoreFormsSendEmailSubmitAction.csproj
+++ b/src/WFFM.ConversionTool.Extensions.SitecoreFormsSendEmailSubmitAction/WFFM.ConversionTool.Extensions.SitecoreFormsSendEmailSubmitAction.csproj
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -56,6 +59,9 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Metadata\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/WFFM.ConversionTool.Extensions.SitecoreFormsSendEmailSubmitAction/packages.config
+++ b/src/WFFM.ConversionTool.Extensions.SitecoreFormsSendEmailSubmitAction/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net471" />
+</packages>


### PR DESCRIPTION
WFFM email save actions whose email body contains double quotes would result in an invalid parameters JSON value, causing the Sitecore Forms editor to display blank email values.  Using a JSON serializer will ensure valid JSON is generated.

Example input causing failure:

```
<host>192.168.1.1</host>
<from>noreply@example.com</from>
<isbodyhtml>true</isbodyhtml>
<to>test@example.com</to>
<cc/>
<bcc>test2@example.com</bcc>
<localfrom>noreply@example.com</localfrom>
<subject>Example</subject>
<mail>
	<strong>
		<span style=\"color: #c00000;\">Details</span>
	</strong>
	<div>
		<strong>Name</strong>:&#160;[<label id=\"{EF3C323A-EA48-4C1C-9CDC-FB7E89F82956}\">Name</label>]
	</div>
</mail>
```

Previous output:

```
{
	"from": "noreply@example.com",
	"to": "test@example.com",
	"cc": "",
	"bcc": "test2@example.com",
	"subject": "Example",
	"message": "<strong><span style="color: #c00000;">Details</span></strong><div><strong>Name</strong>: [Name]</div>",
	"isHtml": true,
	"customSmtpConfig": "<Host>192.168.1.1</Host>"
}
```

New output:

(Double quotes are escaped in `message` field)

```
{
	"from": "noreply@example.com",
	"to": "test@example.com",
	"cc": "",
	"bcc": "test2@example.com",
	"subject": "Example",
	"message": "<strong><span style=\"color: #c00000;\">Details</span></strong><div><strong>Name</strong>: [Name]</div>",
	"isHtml": "true",
	"customSmtpConfig": "<Host>192.168.1.1</Host>"
}
```